### PR TITLE
[@types/google-apps-script] Fix Data Studio Aggregation for NONE

### DIFF
--- a/types/google-apps-script/google-apps-script.data-studio.d.ts
+++ b/types/google-apps-script/google-apps-script.data-studio.d.ts
@@ -10,7 +10,7 @@ declare namespace GoogleAppsScript {
     /**
      * An enum that defines the aggregation types that can be set for a Field.
      */
-    export enum AggregationType { AVG, COUNT, COUNT_DISTINCT, MAX, MIN, SUM, AUTO, NO_AGGREGATION }
+    export enum AggregationType { AVG, COUNT, COUNT_DISTINCT, MAX, MIN, SUM, AUTO, NONE }
 
     /**
      * An enum that defines the authentication types that can be set for a connector.


### PR DESCRIPTION
The change reflects the documentation : https://developers.google.com/datastudio/connector/reference. Section DefaultAggregationType.